### PR TITLE
[FIX] Changed default report font as Arial

### DIFF
--- a/addons/web/static/src/webclient/actions/reports/report.scss
+++ b/addons/web/static/src/webclient/actions/reports/report.scss
@@ -1,4 +1,4 @@
-$o-default-report-font: 'Lato' !default;
+$o-default-report-font: 'Arial' !default;
 $o-default-report-primary-color: rgb(0, 0, 0) !default;
 $o-default-report-secondary-color: rgb(0, 0, 0) !default;
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Change the default font for Altinkaya's reports from `Lato` to `Arial`

Current behavior before PR:
- Font used is `Lato`

Desired behavior after PR is merged:
- Font used is `Arial`



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
