### PR TITLE
[FIX] portal: fix py3o report support

### DIFF
--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -480,8 +480,11 @@ class CustomerPortal(Controller):
             if len(model.company_id) > 1:
                 raise UserError(_('Multi company reports are not supported.'))
             ReportAction = ReportAction.with_company(model.company_id)
-
-        if "py3o" in report_ref:
+        
+        # Check the type of the action to check
+        # if we need to use py3o rendering 
+        action = request.env.ref(report_ref).sudo()
+        if action.report_type == "py3o":
             method_name = '_render_py3o'
         else:
             method_name = '_render_qweb_%s' % (report_type)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Not all actions with py3o templates have `py3o` in their `report_ref`

Current behavior before PR:
Any action with py3o report which doesn't have py3o in their `report_ref` will not render and resut in an error.

Desired behavior after PR is merged:
Any action with py3o report with any `report_ref` would render normally. 



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
