### PR TITLE
[#UMY] fix editor images embedding in pages

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -178,8 +178,10 @@ export const CLIPBOARD_WHITELISTS = {
         // Miscellaneous
         /^btn/,
         /^fa/,
+        // Odoo editor
+        'o_new_image_to_save',
     ],
-    attributes: ['class', 'href', 'src', 'target'],
+    attributes: ['class', 'href', 'src', 'target', 'data-file-name'],
     styledTags: ['SPAN', 'B', 'STRONG', 'I', 'S', 'U', 'FONT', 'TD'],
 };
 
@@ -4710,7 +4712,14 @@ export class OdooEditor extends EventTarget {
         for (const imageFile of imageFiles) {
             const imageNode = document.createElement('img');
             imageNode.style.width = '100%';
-            imageNode.classList.add('img-fluid');
+
+            // EROL FIX:
+
+            // Mark the image as to save to prevent
+            // direct embedding in the pages, used in
+            // wysiwyg.js to query images to upload.
+            imageNode.classList.add('img-fluid', 'o_new_image_to_save');
+
             imageNode.dataset.fileName = imageFile.name;
             promises.push(getImageUrl(imageFile).then(url => {
                 imageNode.src = url;

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -830,6 +830,10 @@ const Wysiwyg = Widget.extend({
         await this.cleanForSave();
 
         const editables = this.options.getContentEditableAreas();
+        
+        // EROL FIX:
+        await this.saveNewImages(editables.length ? $(editables) : this.$editable);
+
         await this.saveModifiedImages(editables.length ? $(editables) : this.$editable);
         await this._saveViewBlocks();
         this.savingContent = false;
@@ -916,6 +920,42 @@ const Wysiwyg = Widget.extend({
                 } else {
                     el.setAttribute('src', newAttachmentSrc);
                 }
+            });
+            return Promise.all(proms);
+        });
+        return Promise.all(defs);
+    },
+    /**
+     * EROL FIX
+     * Create newly added attachments
+     * which haven't yet been uploaded.
+     *
+     * @param {jQuery} $editable
+     * @returns {Promise}
+     */
+    saveNewImages: function ($editable = this.$editable) {
+        const defs = _.map($editable, async editableEl => {
+            const proms = [...editableEl.querySelectorAll('.o_new_image_to_save')].map(async el => {
+                // Creating a new image attachment.
+                const newAttachmentSrc = await this._rpc({
+                    route: `/web_editor/attachment/add_data`,
+                    params: {
+                        data: el.getAttribute("src").split(",")[1],
+                        name: el.dataset.fileName ? el.dataset.fileName : null,
+                        is_image: true,
+                        quality: 80,
+                    },
+                });
+                if (newAttachmentSrc.error) {
+                    el.remove();
+                    return;
+                }
+                el.classList.remove('o_new_image_to_save');
+
+                el.setAttribute('src', newAttachmentSrc.image_src);
+                el.dataset.originalId = newAttachmentSrc.id;
+                el.dataset.mimetype = newAttachmentSrc.mimetype;
+                el.dataset.fileName = newAttachmentSrc.name;
             });
             return Promise.all(proms);
         });


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Images that are being drag and dropped or pasted (or any other way the OdooEditor.js is capable of) are not being uploaded as an attachment and instead becomes an embedded image

Current behavior before PR: Images that are being drag and dropped or pasted (or any other way the OdooEditor.js is capable of) are not being uploaded as an attachment and instead becomes an embedded image


Desired behavior after PR is merged: Images that are being drag and dropped or pasted (or any other way the OdooEditor.js is capable of) are being uploaded as an attachment and are proccessed as needed.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
