### PR TITLE
[#V2T] prevented website from refreshing when cookie accepted

### DIFF
--- a/addons/website/static/src/snippets/s_popup/000.js
+++ b/addons/website/static/src/snippets/s_popup/000.js
@@ -447,6 +447,7 @@ publicWidget.registry.cookies_bar = PopupWidget.extend({
      * @param ev
      */
     _onAcceptClick(ev) {
+        ev.preventDefault();//to prevent site from reloading
         const isFullConsent = ev.target.id === "cookies-consent-all";
         this.cookieValue = `{"required": true, "optional": ${isFullConsent}}`;
         if (isFullConsent) {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The website was refreshing when accepting the cookies, causing informations entered in some pages to be deleted

Current behavior before PR:
When accepting cookies by clicking any button, the website refreshes, deleting any information written by hand. 

Desired behavior after PR is merged:
When accepting cookies by clicking a button; the website will no longer refresh, keeping any information written. 



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
