### PR TITLE
[I18N] base_vat: VAT error translations for all storefront languages

### DIFF
--- a/addons/base_vat/i18n/ar_001.po
+++ b/addons/base_vat/i18n/ar_001.po
@@ -22,20 +22,21 @@ msgstr ""
 msgid ""
 "10XXXXXXXXY or 20XXXXXXXXY or 15XXXXXXXXY or 16XXXXXXXXY or 17XXXXXXXXY"
 msgstr ""
+"10XXXXXXXXY أو 20XXXXXXXXY أو 15XXXXXXXXY أو 16XXXXXXXXY أو 17XXXXXXXXY "
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
-msgid "1111111111 (NIN) or 22222222222 (VKN)"
-msgstr ""
+msgid "17291716060 (NIN) or 1729171602 (VKN)"
+msgstr "17291716060 (NIN) أو 1729171602 (VKN) "
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "1792060346001 or 1792060346"
-msgstr ""
+msgstr "1792060346001 أو 1792060346 "
 
 #. module: base_vat
 #. odoo-python
@@ -49,14 +50,14 @@ msgstr ""
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "310175397400003 [Fifteen digits, first and last digits should be \"3\"]"
-msgstr ""
+msgstr "310175397400003 [مكوّن من 15 رقم، ويجب أن يكون أول وآخر رقم \"3\"] "
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "49-098-576 or 49098576"
-msgstr ""
+msgstr "49-098-576 أو 49098576 "
 
 #. module: base_vat
 #: model_terms:ir.ui.view,arch_db:base_vat.res_config_settings_view_form
@@ -65,27 +66,30 @@ msgid ""
 "specific.\" aria-label=\"Values set here are company-specific.\" "
 "groups=\"base.group_multi_company\" role=\"img\"/>"
 msgstr ""
+"<span class=\"fa fa-lg fa-building-o\" title=\"القيم المحددة هنا خاصة "
+"بالشركة فقط. \" aria-label=\"Values set here are company-specific.\" "
+"groups=\"base.group_multi_company\" role=\"img\"/>"
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "AR200-5536168-2 or 20055361682"
-msgstr ""
+msgstr "AR200-5536168-2 أو 20055361682 "
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "CHE-123.456.788 TVA or CHE-123.456.788 MWST or CHE-123.456.788 IVA"
-msgstr ""
+msgstr "CHE-123.456.788 TVA أو CHE-123.456.788 MWST أو CHE-123.456.788 IVA "
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "CO213123432-1 or CO213.123.432-1"
-msgstr ""
+msgstr "CO213123432-1 أو CO213.123.432-1 "
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_change_ids
@@ -93,7 +97,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_change_ids
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_change_ids
 msgid "Changeset Changes"
-msgstr "Változáskészlet-változások"
+msgstr "تغييرات مجموعة التغييرات"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_ids
@@ -101,22 +105,22 @@ msgstr "Változáskészlet-változások"
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_ids
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_ids
 msgid "Changesets"
-msgstr "Módosításcsomagok"
+msgstr "مجموعات التغييرات"
 
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_res_company
 msgid "Companies"
-msgstr "Vállalatok"
+msgstr "الشركات "
 
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_res_config_settings
 msgid "Config Settings"
-msgstr "Beállítások módosítása"
+msgstr "تهيئة الإعدادات "
 
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_res_partner
 msgid "Contact"
-msgstr "Kapcsolattartó"
+msgstr "جهة الاتصال"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_changesets
@@ -124,7 +128,7 @@ msgstr "Kapcsolattartó"
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_changesets
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__count_changesets
 msgid "Count Changesets"
-msgstr "Módosításcsomagok számlálása"
+msgstr "عدد التغييرات"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changeset_changes
@@ -132,7 +136,7 @@ msgstr "Módosításcsomagok számlálása"
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changeset_changes
 msgid "Count Pending Changeset Changes"
-msgstr "Számolja a függőben lévő változtatáskészlet-változásokat"
+msgstr "عدد تغييرات مجموعة التغييرات المعلقة"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changesets
@@ -140,21 +144,21 @@ msgstr "Számolja a függőben lévő változtatáskészlet-változásokat"
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changesets
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changesets
 msgid "Count Pending Changesets"
-msgstr "Függő módosításkészletek számolása"
+msgstr "عدد مجموعات التغييرات المعلقة"
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "DE123456788 or 12/345/67890"
-msgstr ""
+msgstr "DE123456788 أو 12/345/67890 "
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "DO1-01-85004-3 or 101850043"
-msgstr ""
+msgstr "DO1-01-85004-3 أو 101850043 "
 
 #. module: base_vat
 #. odoo-python
@@ -162,26 +166,26 @@ msgstr ""
 #, python-format
 msgid ""
 "Example: '219999830019' (format: 12 digits, all numbers, valid check digit)"
-msgstr ""
+msgstr "مثال: ”219999830019“ (التنسيق: 12 رقم، كافة الأرقام، رقم شيك صالح) "
 
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_account_fiscal_position
 msgid "Fiscal Position"
-msgstr "Pénzügyi pozíció"
+msgstr "الوضع المالي "
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "GB123456782 or XI123456782"
-msgstr ""
+msgstr "GB123456782 أو XI123456782 "
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "HU12345676 or 12345678-1-11 or 8071592153"
-msgstr ""
+msgstr "HU12345676 أو 12345678-1-11 أو 8071592153 "
 
 #. module: base_vat
 #: model_terms:ir.ui.view,arch_db:base_vat.res_config_settings_view_form
@@ -189,13 +193,15 @@ msgid ""
 "If this checkbox is ticked, you will not be able to save a contact if its "
 "VAT number cannot be verified by the European VIES service."
 msgstr ""
+"إذا تم تحديد هذا المربع، لن تتمكن من حفظ جهة اتصال إذا تعذر التحقق من رقم "
+"الضريبة الخاص بها من قِبَل خدمة VIES الأوروبية."
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "MXGODE561231GR8 or GODE561231GR8"
-msgstr ""
+msgstr "MXGODE561231GR8 أو GODE561231GR8 "
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__smart_search
@@ -203,13 +209,15 @@ msgstr ""
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__smart_search
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__smart_search
 msgid "Smart Search"
-msgstr "Intelligens keresés"
+msgstr "البحث الذكي"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__vies_failed_message
 #: model:ir.model.fields,field_description:base_vat.field_res_users__vies_failed_message
 msgid "Technical field display a message to the user if the VIES check fails."
 msgstr ""
+"حقل تقني يعرض رسالة للمستخدم في حال فشل فحص نظام تبادل معلومات الضريبة "
+"(VIES). "
 
 #. module: base_vat
 #. odoo-python
@@ -219,8 +227,8 @@ msgid ""
 "The %(vat_label)s number [%(wrong_vat)s] does not seem to be valid. \n"
 "Note: the expected format is %(expected_format)s"
 msgstr ""
-"A(z) %(vat_label)s szám [%(wrong_vat)s] érvénytelennek tűnik. \n"
-"Megjegyzés: a várt formátum %(expected_format)s"
+"يبدو أن %(vat_label)s رقم [%(wrong_vat)s] غير صالحة. \n"
+"ملاحظة: التنسيق المتوقع هو %(expected_format)s "
 
 #. module: base_vat
 #. odoo-python
@@ -230,8 +238,8 @@ msgid ""
 "The %(vat_label)s number [%(wrong_vat)s] for %(record_label)s does not seem to be valid. \n"
 "Note: the expected format is %(expected_format)s"
 msgstr ""
-"A(z) %(vat_label)s szám [%(wrong_vat)s] a(z) %(record_label)s esetében érvénytelennek tűnik. \n"
-"Megjegyzés: a várt formátum %(expected_format)s"
+"يبدو أن رقم %(vat_label)s  [%(wrong_vat)s] لـ %(record_label)s غير صالح. \n"
+"ملاحظة: الصيغة المتوقعة هي %(expected_format)s "
 
 #. module: base_vat
 #. odoo-python
@@ -239,6 +247,7 @@ msgstr ""
 #, python-format
 msgid "The VAT number %s failed the VIES VAT validation check."
 msgstr ""
+"لقد فشل رقم الضريبة %s في اختبار التحقق من نظام تبادل معلومات الضريبة. "
 
 #. module: base_vat
 #. odoo-python
@@ -248,6 +257,8 @@ msgid ""
 "The country detected for this foreign VAT number does not match any of the "
 "countries composing the country group set on this fiscal position."
 msgstr ""
+"لا تطابق الدولة التي تم رصدها لرقم ضريبة القيمة المضافة هذا أي من الدول التي"
+" تشكّل مجموعة الدولة التي تم تعيينها لهذا الوضع المالي. "
 
 #. module: base_vat
 #. odoo-python
@@ -257,6 +268,8 @@ msgid ""
 "The country of the foreign VAT number could not be detected. Please assign a"
 " country to the fiscal position or set a country group"
 msgstr ""
+"تعذر رصد دولة رقم ضريبة القيمة المضافة الأجنبية. يُرجى تعيين دولة للوضع "
+"المالي أو قم بتعيين مجموعة دولة "
 
 #. module: base_vat
 #: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changeset_changes
@@ -264,7 +277,7 @@ msgstr ""
 #: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changeset_changes
 #: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changeset_changes
 msgid "The number of pending changes of this record"
-msgstr "A bejegyzés függőben lévő módosításainak száma"
+msgstr "عدد التغييرات المعلقة لهذا السجل"
 
 #. module: base_vat
 #: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changesets
@@ -272,7 +285,7 @@ msgstr "A bejegyzés függőben lévő módosításainak száma"
 #: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changesets
 #: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changesets
 msgid "The number of pending changesets of this record"
-msgstr "A rekord folyamatban lévő módosításainak száma"
+msgstr "عدد مجموعات التغييرات المعلقة لهذا السجل"
 
 #. module: base_vat
 #: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_changesets
@@ -280,7 +293,7 @@ msgstr "A rekord folyamatban lévő módosításainak száma"
 #: model:ir.model.fields,help:base_vat.field_res_config_settings__count_changesets
 #: model:ir.model.fields,help:base_vat.field_res_partner__count_changesets
 msgid "The overall number of changesets of this record"
-msgstr "Az e rekordhoz tartozó módosítások teljes száma"
+msgstr "العدد الإجمالي للتغييرات في هذا السجل"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__user_can_see_changeset
@@ -288,25 +301,25 @@ msgstr "Az e rekordhoz tartozó módosítások teljes száma"
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__user_can_see_changeset
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__user_can_see_changeset
 msgid "User Can See Changeset"
-msgstr "A felhasználó láthatja a változtatáskészletet"
+msgstr "يمكن للمستخدم الاطلاع على مجموعة التغييرات"
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "VAT"
-msgstr "Adószám"
+msgstr "ضريبة القيمة المضافة"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_res_company__vat_check_vies
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__vat_check_vies
 msgid "Verify VAT Numbers"
-msgstr "Adószámok ellenőrzése"
+msgstr "التحقق من أرقام الضريبة "
 
 #. module: base_vat
 #: model_terms:ir.ui.view,arch_db:base_vat.res_config_settings_view_form
 msgid "Verify VAT numbers using the European VIES service"
-msgstr "Ellenőrizze az adószámokat az európai VIES szolgáltatáson keresztül"
+msgstr "التحقق من أرقام قيمة الضريبة المضافة باستخدام خدمة VIES الأوروبية"
 
 #. module: base_vat
 #. odoo-python
@@ -314,24 +327,25 @@ msgstr "Ellenőrizze az adószámokat az európai VIES szolgáltatáson kereszt�
 #, python-format
 msgid "XXXXXXXXX [9 digits] and it should respect the Luhn algorithm checksum"
 msgstr ""
+"XXXXXXXXX [9 أرقام] ويجب أن تضع بعين الاعتبار Luhn algorithm checksum "
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "either 11 digits for CPF or 14 digits for CNPJ"
-msgstr ""
+msgstr "إما 11 رقم لـ CPF أو 14 رقم لـ CNPJ "
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/account_fiscal_position.py:0
 #, python-format
 msgid "fiscal position [%s]"
-msgstr ""
+msgstr "الوضع المالي [%s] "
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "partner [%s]"
-msgstr ""
+msgstr "الشريك [%s] "

--- a/addons/base_vat/i18n/base_vat.pot
+++ b/addons/base_vat/i18n/base_vat.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-10 08:27+0000\n"
-"PO-Revision-Date: 2025-02-10 08:27+0000\n"
+"POT-Creation-Date: 2026-06-08 14:51+0000\n"
+"PO-Revision-Date: 2026-06-08 14:51+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -88,6 +88,22 @@ msgid "CO213123432-1 or CO213.123.432-1"
 msgstr ""
 
 #. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_company__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_change_ids
+msgid "Changeset Changes"
+msgstr ""
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_company__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_ids
+msgid "Changesets"
+msgstr ""
+
+#. module: base_vat
 #: model:ir.model,name:base_vat.model_res_company
 msgid "Companies"
 msgstr ""
@@ -100,6 +116,30 @@ msgstr ""
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_res_partner
 msgid "Contact"
+msgstr ""
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_changesets
+msgid "Count Changesets"
+msgstr ""
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changeset_changes
+msgid "Count Pending Changeset Changes"
+msgstr ""
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changesets
+msgid "Count Pending Changesets"
 msgstr ""
 
 #. module: base_vat
@@ -158,6 +198,14 @@ msgid "MXGODE561231GR8 or GODE561231GR8"
 msgstr ""
 
 #. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_company__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__smart_search
+msgid "Smart Search"
+msgstr ""
+
+#. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__vies_failed_message
 #: model:ir.model.fields,field_description:base_vat.field_res_users__vies_failed_message
 msgid "Technical field display a message to the user if the VIES check fails."
@@ -204,6 +252,38 @@ msgstr ""
 msgid ""
 "The country of the foreign VAT number could not be detected. Please assign a"
 " country to the fiscal position or set a country group"
+msgstr ""
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_company__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changeset_changes
+msgid "The number of pending changes of this record"
+msgstr ""
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_company__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changesets
+msgid "The number of pending changesets of this record"
+msgstr ""
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_company__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_changesets
+msgid "The overall number of changesets of this record"
+msgstr ""
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_company__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__user_can_see_changeset
+msgid "User Can See Changeset"
 msgstr ""
 
 #. module: base_vat

--- a/addons/base_vat/i18n/bg.po
+++ b/addons/base_vat/i18n/bg.po
@@ -1,26 +1,19 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # 	* base_vat
-# 
-# Translators:
-# KeyVillage, 2023
-# aleksandar ivanov, 2023
-# Maria Boyadjieva <marabo2000@gmail.com>, 2023
-# Albena Mincheva <albena_vicheva@abv.bg>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-10 08:27+0000\n"
-"PO-Revision-Date: 2022-09-22 05:45+0000\n"
-"Last-Translator: Albena Mincheva <albena_vicheva@abv.bg>, 2023\n"
-"Language-Team: Bulgarian (https://app.transifex.com/odoo/teams/41243/bg/)\n"
+"POT-Creation-Date: 2026-06-08 14:51+0000\n"
+"PO-Revision-Date: 2026-06-08 14:51+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: bg\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: base_vat
 #. odoo-python
@@ -72,9 +65,6 @@ msgid ""
 "specific.\" aria-label=\"Values set here are company-specific.\" "
 "groups=\"base.group_multi_company\" role=\"img\"/>"
 msgstr ""
-"<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-"
-"specific.\" aria-label=\"Values set here are company-specific.\" "
-"groups=\"base.group_multi_company\" role=\"img\"/>"
 
 #. module: base_vat
 #. odoo-python
@@ -98,6 +88,22 @@ msgid "CO213123432-1 or CO213.123.432-1"
 msgstr ""
 
 #. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_company__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_change_ids
+msgid "Changeset Changes"
+msgstr "Промени в набора от промени"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_company__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_ids
+msgid "Changesets"
+msgstr "Промени"
+
+#. module: base_vat
 #: model:ir.model,name:base_vat.model_res_company
 msgid "Companies"
 msgstr "Фирми"
@@ -111,6 +117,30 @@ msgstr "Настройки"
 #: model:ir.model,name:base_vat.model_res_partner
 msgid "Contact"
 msgstr "Контакт"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_changesets
+msgid "Count Changesets"
+msgstr "Промени в броя"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changeset_changes
+msgid "Count Pending Changeset Changes"
+msgstr "Отчитане на чакащите промени в набора от промени"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changesets
+msgid "Count Pending Changesets"
+msgstr "Брой чакащи промени"
 
 #. module: base_vat
 #. odoo-python
@@ -170,6 +200,14 @@ msgid "MXGODE561231GR8 or GODE561231GR8"
 msgstr ""
 
 #. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_company__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__smart_search
+msgid "Smart Search"
+msgstr "Интелигентно търсене"
+
+#. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__vies_failed_message
 #: model:ir.model.fields,field_description:base_vat.field_res_users__vies_failed_message
 msgid "Technical field display a message to the user if the VIES check fails."
@@ -183,6 +221,8 @@ msgid ""
 "The %(vat_label)s number [%(wrong_vat)s] does not seem to be valid. \n"
 "Note: the expected format is %(expected_format)s"
 msgstr ""
+"Номерът %(vat_label)s [%(wrong_vat)s] изглежда невалиден. \n"
+"Забележка: очакваният формат е %(expected_format)s"
 
 #. module: base_vat
 #. odoo-python
@@ -192,6 +232,8 @@ msgid ""
 "The %(vat_label)s number [%(wrong_vat)s] for %(record_label)s does not seem to be valid. \n"
 "Note: the expected format is %(expected_format)s"
 msgstr ""
+"Номерът %(vat_label)s [%(wrong_vat)s] за %(record_label)s изглежда невалиден. \n"
+"Забележка: очакваният формат е %(expected_format)s"
 
 #. module: base_vat
 #. odoo-python
@@ -217,6 +259,38 @@ msgid ""
 "The country of the foreign VAT number could not be detected. Please assign a"
 " country to the fiscal position or set a country group"
 msgstr ""
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_company__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changeset_changes
+msgid "The number of pending changes of this record"
+msgstr "Брой на предстоящите промени на този запис"
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_company__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changesets
+msgid "The number of pending changesets of this record"
+msgstr "Броят на чакащите промени в този запис"
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_company__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_changesets
+msgid "The overall number of changesets of this record"
+msgstr "Общ брой на промените в този запис"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_company__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__user_can_see_changeset
+msgid "User Can See Changeset"
+msgstr "Потребителят може да види набора от промени"
 
 #. module: base_vat
 #. odoo-python

--- a/addons/base_vat/i18n/de.po
+++ b/addons/base_vat/i18n/de.po
@@ -1,25 +1,19 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # 	* base_vat
-# 
-# Translators:
-# Martin Trigaux, 2023
-# Larissa Manderfeld, 2024
-# Wil Odoo, 2025
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-10 08:27+0000\n"
-"PO-Revision-Date: 2022-09-22 05:45+0000\n"
-"Last-Translator: Wil Odoo, 2025\n"
-"Language-Team: German (https://app.transifex.com/odoo/teams/41243/de/)\n"
+"POT-Creation-Date: 2026-06-08 14:51+0000\n"
+"PO-Revision-Date: 2026-06-08 14:51+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: de\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: base_vat
 #. odoo-python
@@ -50,7 +44,7 @@ msgstr "1792060346001 oder 1792060346"
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "3101012009"
-msgstr "3101012009"
+msgstr ""
 
 #. module: base_vat
 #. odoo-python
@@ -74,9 +68,6 @@ msgid ""
 "specific.\" aria-label=\"Values set here are company-specific.\" "
 "groups=\"base.group_multi_company\" role=\"img\"/>"
 msgstr ""
-"<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-"
-"specific.\" aria-label=\"Values set here are company-specific.\" "
-"groups=\"base.group_multi_company\" role=\"img\"/>"
 
 #. module: base_vat
 #. odoo-python
@@ -101,6 +92,22 @@ msgid "CO213123432-1 or CO213.123.432-1"
 msgstr "CO213123432-1 oder CO213.123.432-1"
 
 #. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_company__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_change_ids
+msgid "Changeset Changes"
+msgstr "Changeset Änderungen"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_company__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_ids
+msgid "Changesets"
+msgstr "Änderungssätze"
+
+#. module: base_vat
 #: model:ir.model,name:base_vat.model_res_company
 msgid "Companies"
 msgstr "Unternehmen"
@@ -108,12 +115,36 @@ msgstr "Unternehmen"
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_res_config_settings
 msgid "Config Settings"
-msgstr "Konfigurationseinstellungen"
+msgstr "Konfigurationseinstellungen "
 
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_res_partner
 msgid "Contact"
 msgstr "Kontakt"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_changesets
+msgid "Count Changesets"
+msgstr "Changesets zählen"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changeset_changes
+msgid "Count Pending Changeset Changes"
+msgstr "Ausstehende Changeset-Änderungen zählen"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changesets
+msgid "Count Pending Changesets"
+msgstr "Ausstehende Changesets zählen"
 
 #. module: base_vat
 #. odoo-python
@@ -177,6 +208,14 @@ msgid "MXGODE561231GR8 or GODE561231GR8"
 msgstr "MXGODE561231GR8 oder GODE561231GR8"
 
 #. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_company__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__smart_search
+msgid "Smart Search"
+msgstr "Intelligente Suche"
+
+#. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__vies_failed_message
 #: model:ir.model.fields,field_description:base_vat.field_res_users__vies_failed_message
 msgid "Technical field display a message to the user if the VIES check fails."
@@ -236,6 +275,38 @@ msgstr ""
 "Das Land der ausländischen MwSt.-Nummer konnte nicht erkannt werden. Bitte "
 "weisen Sie der Steuerposition ein Land zu oder legen Sie eine Ländergruppe "
 "fest"
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_company__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changeset_changes
+msgid "The number of pending changes of this record"
+msgstr "Die Anzahl der ausstehenden Änderungen in diesem Datensatz"
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_company__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changesets
+msgid "The number of pending changesets of this record"
+msgstr "Die Anzahl der ausstehenden Changesets dieses Datensatzes"
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_company__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_changesets
+msgid "The overall number of changesets of this record"
+msgstr "Die Gesamtzahl der Änderungen in diesem Datensatz"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_company__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__user_can_see_changeset
+msgid "User Can See Changeset"
+msgstr "Benutzer kann Changeset sehen"
 
 #. module: base_vat
 #. odoo-python

--- a/addons/base_vat/i18n/el_GR.po
+++ b/addons/base_vat/i18n/el_GR.po
@@ -27,7 +27,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
-msgid "1111111111 (NIN) or 22222222222 (VKN)"
+msgid "17291716060 (NIN) or 1729171602 (VKN)"
 msgstr ""
 
 #. module: base_vat
@@ -93,7 +93,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_change_ids
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_change_ids
 msgid "Changeset Changes"
-msgstr "Változáskészlet-változások"
+msgstr "Αλλαγές σετ αλλαγών"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_ids
@@ -101,22 +101,22 @@ msgstr "Változáskészlet-változások"
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_ids
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_ids
 msgid "Changesets"
-msgstr "Módosításcsomagok"
+msgstr "Σύνολα αλλαγών"
 
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_res_company
 msgid "Companies"
-msgstr "Vállalatok"
+msgstr "Εταιρίες"
 
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_res_config_settings
 msgid "Config Settings"
-msgstr "Beállítások módosítása"
+msgstr "Ρυθμίσεις διαμόρφωσης"
 
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_res_partner
 msgid "Contact"
-msgstr "Kapcsolattartó"
+msgstr "Επαφή"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_changesets
@@ -124,7 +124,7 @@ msgstr "Kapcsolattartó"
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_changesets
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__count_changesets
 msgid "Count Changesets"
-msgstr "Módosításcsomagok számlálása"
+msgstr "Πλήθος συνόλων αλλαγών"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changeset_changes
@@ -132,7 +132,7 @@ msgstr "Módosításcsomagok számlálása"
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changeset_changes
 msgid "Count Pending Changeset Changes"
-msgstr "Számolja a függőben lévő változtatáskészlet-változásokat"
+msgstr "Μετρήστε τις αλλαγές που εκκρεμούν"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changesets
@@ -140,7 +140,7 @@ msgstr "Számolja a függőben lévő változtatáskészlet-változásokat"
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changesets
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changesets
 msgid "Count Pending Changesets"
-msgstr "Függő módosításkészletek számolása"
+msgstr "Μετρήστε τα σύνολα αλλαγών που εκκρεμούν"
 
 #. module: base_vat
 #. odoo-python
@@ -167,7 +167,7 @@ msgstr ""
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_account_fiscal_position
 msgid "Fiscal Position"
-msgstr "Pénzügyi pozíció"
+msgstr "Φορολογική Θέση"
 
 #. module: base_vat
 #. odoo-python
@@ -203,7 +203,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__smart_search
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__smart_search
 msgid "Smart Search"
-msgstr "Intelligens keresés"
+msgstr "Έξυπνη αναζήτηση"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__vies_failed_message
@@ -219,8 +219,8 @@ msgid ""
 "The %(vat_label)s number [%(wrong_vat)s] does not seem to be valid. \n"
 "Note: the expected format is %(expected_format)s"
 msgstr ""
-"A(z) %(vat_label)s szám [%(wrong_vat)s] érvénytelennek tűnik. \n"
-"Megjegyzés: a várt formátum %(expected_format)s"
+"Ο αριθμός %(vat_label)s [%(wrong_vat)s] δεν φαίνεται έγκυρος. \n"
+"Σημείωση: η αναμενόμενη μορφή είναι %(expected_format)s"
 
 #. module: base_vat
 #. odoo-python
@@ -230,8 +230,8 @@ msgid ""
 "The %(vat_label)s number [%(wrong_vat)s] for %(record_label)s does not seem to be valid. \n"
 "Note: the expected format is %(expected_format)s"
 msgstr ""
-"A(z) %(vat_label)s szám [%(wrong_vat)s] a(z) %(record_label)s esetében érvénytelennek tűnik. \n"
-"Megjegyzés: a várt formátum %(expected_format)s"
+"Ο αριθμός %(vat_label)s [%(wrong_vat)s] για %(record_label)s δεν φαίνεται έγκυρος. \n"
+"Σημείωση: η αναμενόμενη μορφή είναι %(expected_format)s"
 
 #. module: base_vat
 #. odoo-python
@@ -264,7 +264,7 @@ msgstr ""
 #: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changeset_changes
 #: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changeset_changes
 msgid "The number of pending changes of this record"
-msgstr "A bejegyzés függőben lévő módosításainak száma"
+msgstr "Ο αριθμός των εκκρεμών αλλαγών αυτής της εγγραφής"
 
 #. module: base_vat
 #: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changesets
@@ -272,7 +272,7 @@ msgstr "A bejegyzés függőben lévő módosításainak száma"
 #: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changesets
 #: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changesets
 msgid "The number of pending changesets of this record"
-msgstr "A rekord folyamatban lévő módosításainak száma"
+msgstr "Ο αριθμός των εκκρεμών συνόλων αλλαγών αυτής της εγγραφής"
 
 #. module: base_vat
 #: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_changesets
@@ -280,7 +280,7 @@ msgstr "A rekord folyamatban lévő módosításainak száma"
 #: model:ir.model.fields,help:base_vat.field_res_config_settings__count_changesets
 #: model:ir.model.fields,help:base_vat.field_res_partner__count_changesets
 msgid "The overall number of changesets of this record"
-msgstr "Az e rekordhoz tartozó módosítások teljes száma"
+msgstr "Ο συνολικός αριθμός των αλλαγών αυτού του αρχείου"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__user_can_see_changeset
@@ -288,25 +288,26 @@ msgstr "Az e rekordhoz tartozó módosítások teljes száma"
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__user_can_see_changeset
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__user_can_see_changeset
 msgid "User Can See Changeset"
-msgstr "A felhasználó láthatja a változtatáskészletet"
+msgstr "Ο χρήστης μπορεί να δει το σύνολο αλλαγών"
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "VAT"
-msgstr "Adószám"
+msgstr "ΦΠΑ"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_res_company__vat_check_vies
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__vat_check_vies
 msgid "Verify VAT Numbers"
-msgstr "Adószámok ellenőrzése"
+msgstr "Επαληθεύστε τους αριθμούς ΑΦΜ"
 
 #. module: base_vat
 #: model_terms:ir.ui.view,arch_db:base_vat.res_config_settings_view_form
 msgid "Verify VAT numbers using the European VIES service"
-msgstr "Ellenőrizze az adószámokat az európai VIES szolgáltatáson keresztül"
+msgstr ""
+"Επαληθεύστε τους αριθμούς ΑΦΜ που χρησιμοποιούν την Ευρωπαϊκή  VIES υπηρεσία"
 
 #. module: base_vat
 #. odoo-python

--- a/addons/base_vat/i18n/en_US.po
+++ b/addons/base_vat/i18n/en_US.po
@@ -27,7 +27,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
-msgid "1111111111 (NIN) or 22222222222 (VKN)"
+msgid "17291716060 (NIN) or 1729171602 (VKN)"
 msgstr ""
 
 #. module: base_vat
@@ -93,7 +93,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_change_ids
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_change_ids
 msgid "Changeset Changes"
-msgstr "Változáskészlet-változások"
+msgstr ""
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_ids
@@ -101,22 +101,22 @@ msgstr "Változáskészlet-változások"
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_ids
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_ids
 msgid "Changesets"
-msgstr "Módosításcsomagok"
+msgstr ""
 
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_res_company
 msgid "Companies"
-msgstr "Vállalatok"
+msgstr ""
 
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_res_config_settings
 msgid "Config Settings"
-msgstr "Beállítások módosítása"
+msgstr ""
 
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_res_partner
 msgid "Contact"
-msgstr "Kapcsolattartó"
+msgstr ""
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_changesets
@@ -124,7 +124,7 @@ msgstr "Kapcsolattartó"
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_changesets
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__count_changesets
 msgid "Count Changesets"
-msgstr "Módosításcsomagok számlálása"
+msgstr ""
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changeset_changes
@@ -132,7 +132,7 @@ msgstr "Módosításcsomagok számlálása"
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changeset_changes
 msgid "Count Pending Changeset Changes"
-msgstr "Számolja a függőben lévő változtatáskészlet-változásokat"
+msgstr ""
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changesets
@@ -140,7 +140,7 @@ msgstr "Számolja a függőben lévő változtatáskészlet-változásokat"
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changesets
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changesets
 msgid "Count Pending Changesets"
-msgstr "Függő módosításkészletek számolása"
+msgstr ""
 
 #. module: base_vat
 #. odoo-python
@@ -167,7 +167,7 @@ msgstr ""
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_account_fiscal_position
 msgid "Fiscal Position"
-msgstr "Pénzügyi pozíció"
+msgstr ""
 
 #. module: base_vat
 #. odoo-python
@@ -203,7 +203,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__smart_search
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__smart_search
 msgid "Smart Search"
-msgstr "Intelligens keresés"
+msgstr ""
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__vies_failed_message
@@ -219,8 +219,6 @@ msgid ""
 "The %(vat_label)s number [%(wrong_vat)s] does not seem to be valid. \n"
 "Note: the expected format is %(expected_format)s"
 msgstr ""
-"A(z) %(vat_label)s szám [%(wrong_vat)s] érvénytelennek tűnik. \n"
-"Megjegyzés: a várt formátum %(expected_format)s"
 
 #. module: base_vat
 #. odoo-python
@@ -230,8 +228,6 @@ msgid ""
 "The %(vat_label)s number [%(wrong_vat)s] for %(record_label)s does not seem to be valid. \n"
 "Note: the expected format is %(expected_format)s"
 msgstr ""
-"A(z) %(vat_label)s szám [%(wrong_vat)s] a(z) %(record_label)s esetében érvénytelennek tűnik. \n"
-"Megjegyzés: a várt formátum %(expected_format)s"
 
 #. module: base_vat
 #. odoo-python
@@ -264,7 +260,7 @@ msgstr ""
 #: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changeset_changes
 #: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changeset_changes
 msgid "The number of pending changes of this record"
-msgstr "A bejegyzés függőben lévő módosításainak száma"
+msgstr ""
 
 #. module: base_vat
 #: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changesets
@@ -272,7 +268,7 @@ msgstr "A bejegyzés függőben lévő módosításainak száma"
 #: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changesets
 #: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changesets
 msgid "The number of pending changesets of this record"
-msgstr "A rekord folyamatban lévő módosításainak száma"
+msgstr ""
 
 #. module: base_vat
 #: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_changesets
@@ -280,7 +276,7 @@ msgstr "A rekord folyamatban lévő módosításainak száma"
 #: model:ir.model.fields,help:base_vat.field_res_config_settings__count_changesets
 #: model:ir.model.fields,help:base_vat.field_res_partner__count_changesets
 msgid "The overall number of changesets of this record"
-msgstr "Az e rekordhoz tartozó módosítások teljes száma"
+msgstr ""
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__user_can_see_changeset
@@ -288,25 +284,25 @@ msgstr "Az e rekordhoz tartozó módosítások teljes száma"
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__user_can_see_changeset
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__user_can_see_changeset
 msgid "User Can See Changeset"
-msgstr "A felhasználó láthatja a változtatáskészletet"
+msgstr ""
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "VAT"
-msgstr "Adószám"
+msgstr ""
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_res_company__vat_check_vies
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__vat_check_vies
 msgid "Verify VAT Numbers"
-msgstr "Adószámok ellenőrzése"
+msgstr ""
 
 #. module: base_vat
 #: model_terms:ir.ui.view,arch_db:base_vat.res_config_settings_view_form
 msgid "Verify VAT numbers using the European VIES service"
-msgstr "Ellenőrizze az adószámokat az európai VIES szolgáltatáson keresztül"
+msgstr ""
 
 #. module: base_vat
 #. odoo-python

--- a/addons/base_vat/i18n/es.po
+++ b/addons/base_vat/i18n/es.po
@@ -1,26 +1,19 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # 	* base_vat
-# 
-# Translators:
-# Martin Trigaux, 2022
-# Pedro M. Baeza <pedro.baeza@tecnativa.com>, 2024
-# Larissa Manderfeld, 2024
-# Wil Odoo, 2025
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-10 08:27+0000\n"
-"PO-Revision-Date: 2022-09-22 05:45+0000\n"
-"Last-Translator: Wil Odoo, 2025\n"
-"Language-Team: Spanish (https://app.transifex.com/odoo/teams/41243/es/)\n"
+"POT-Creation-Date: 2026-06-08 14:51+0000\n"
+"PO-Revision-Date: 2026-06-08 14:51+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Plural-Forms: \n"
 
 #. module: base_vat
 #. odoo-python
@@ -49,7 +42,7 @@ msgstr "1792060346001 o 1792060346"
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "3101012009"
-msgstr "3101012009"
+msgstr ""
 
 #. module: base_vat
 #. odoo-python
@@ -72,9 +65,6 @@ msgid ""
 "specific.\" aria-label=\"Values set here are company-specific.\" "
 "groups=\"base.group_multi_company\" role=\"img\"/>"
 msgstr ""
-"<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-"
-"specific.\" aria-label=\"Values set here are company-specific.\" "
-"groups=\"base.group_multi_company\" role=\"img\"/>"
 
 #. module: base_vat
 #. odoo-python
@@ -98,6 +88,22 @@ msgid "CO213123432-1 or CO213.123.432-1"
 msgstr "CO213123432-1 o CO213.123.432-1"
 
 #. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_company__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_change_ids
+msgid "Changeset Changes"
+msgstr "Cambios en el conjunto de cambios"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_company__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_ids
+msgid "Changesets"
+msgstr "Conjuntos de cambios"
+
+#. module: base_vat
 #: model:ir.model,name:base_vat.model_res_company
 msgid "Companies"
 msgstr "Compañías"
@@ -111,6 +117,30 @@ msgstr "Ajustes de configuración"
 #: model:ir.model,name:base_vat.model_res_partner
 msgid "Contact"
 msgstr "Contacto"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_changesets
+msgid "Count Changesets"
+msgstr "Contar los cambios"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changeset_changes
+msgid "Count Pending Changeset Changes"
+msgstr "Contar cambios pendientes"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changesets
+msgid "Count Pending Changesets"
+msgstr "Contar conjuntos de cambios pendientes"
 
 #. module: base_vat
 #. odoo-python
@@ -172,6 +202,14 @@ msgid "MXGODE561231GR8 or GODE561231GR8"
 msgstr "MXGODE561231GR8 o GODE561231GR8"
 
 #. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_company__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__smart_search
+msgid "Smart Search"
+msgstr "Búsqueda inteligente"
+
+#. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__vies_failed_message
 #: model:ir.model.fields,field_description:base_vat.field_res_users__vies_failed_message
 msgid "Technical field display a message to the user if the VIES check fails."
@@ -231,6 +269,38 @@ msgid ""
 msgstr ""
 "No se ha podido detectar el país del NIF extranjero. Asigne un país a la "
 "posición fiscal o establezca un grupo de países"
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_company__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changeset_changes
+msgid "The number of pending changes of this record"
+msgstr "El número de cambios pendientes de este registro"
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_company__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changesets
+msgid "The number of pending changesets of this record"
+msgstr "El número de cambios pendientes de este registro"
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_company__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_changesets
+msgid "The overall number of changesets of this record"
+msgstr "El número total de cambios de este registro"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_company__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__user_can_see_changeset
+msgid "User Can See Changeset"
+msgstr "El usuario puede ver el conjunto de cambios"
 
 #. module: base_vat
 #. odoo-python

--- a/addons/base_vat/i18n/fr.po
+++ b/addons/base_vat/i18n/fr.po
@@ -1,26 +1,19 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # 	* base_vat
-# 
-# Translators:
-# Martin Trigaux, 2023
-# Jolien De Paepe, 2023
-# Manon Rondou, 2025
-# Wil Odoo, 2025
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-10 08:27+0000\n"
-"PO-Revision-Date: 2022-09-22 05:45+0000\n"
-"Last-Translator: Wil Odoo, 2025\n"
-"Language-Team: French (https://app.transifex.com/odoo/teams/41243/fr/)\n"
+"POT-Creation-Date: 2026-06-08 14:51+0000\n"
+"PO-Revision-Date: 2026-06-08 14:51+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: fr\n"
-"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Plural-Forms: \n"
 
 #. module: base_vat
 #. odoo-python
@@ -50,7 +43,7 @@ msgstr "1792060346001 ou 1792060346"
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "3101012009"
-msgstr "3101012009"
+msgstr ""
 
 #. module: base_vat
 #. odoo-python
@@ -102,9 +95,25 @@ msgid "CO213123432-1 or CO213.123.432-1"
 msgstr "CO213123432-1 ou CO213.123.432-1"
 
 #. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_company__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_change_ids
+msgid "Changeset Changes"
+msgstr "Modifications du jeu de modifications"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_company__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_ids
+msgid "Changesets"
+msgstr "Changements"
+
+#. module: base_vat
 #: model:ir.model,name:base_vat.model_res_company
 msgid "Companies"
-msgstr "Sociétés"
+msgstr "Entreprises"
 
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_res_config_settings
@@ -114,7 +123,31 @@ msgstr "Paramètres de configuration"
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_res_partner
 msgid "Contact"
-msgstr "Contact"
+msgstr ""
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_changesets
+msgid "Count Changesets"
+msgstr "Comptez les modifications"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changeset_changes
+msgid "Count Pending Changeset Changes"
+msgstr "Comptez les modifications en cours du jeu de modifications"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changesets
+msgid "Count Pending Changesets"
+msgstr "Comptez les jeux de modifications en attente"
 
 #. module: base_vat
 #. odoo-python
@@ -176,6 +209,14 @@ msgid "MXGODE561231GR8 or GODE561231GR8"
 msgstr "MXGODE561231GR8 ou GODE561231GR8"
 
 #. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_company__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__smart_search
+msgid "Smart Search"
+msgstr "Recherche intelligente"
+
+#. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__vies_failed_message
 #: model:ir.model.fields,field_description:base_vat.field_res_users__vies_failed_message
 msgid "Technical field display a message to the user if the VIES check fails."
@@ -233,6 +274,38 @@ msgid ""
 msgstr ""
 "Le pays pour ce numéro de TVA étranger n'a pas pu être détecté. Veuillez "
 "attribuer un pays à la position fiscale ou définir un groupe de pays."
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_company__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changeset_changes
+msgid "The number of pending changes of this record"
+msgstr "Le nombre de modifications en attente de cet enregistrement"
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_company__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changesets
+msgid "The number of pending changesets of this record"
+msgstr "Le nombre de jeux de modifications en attente pour cet enregistrement"
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_company__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_changesets
+msgid "The overall number of changesets of this record"
+msgstr "Le nombre total de modifications de cet enregistrement"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_company__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__user_can_see_changeset
+msgid "User Can See Changeset"
+msgstr "L'utilisateur peut voir le jeu de modifications"
 
 #. module: base_vat
 #. odoo-python

--- a/addons/base_vat/i18n/it.po
+++ b/addons/base_vat/i18n/it.po
@@ -1,26 +1,19 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # 	* base_vat
-# 
-# Translators:
-# Martin Trigaux, 2023
-# Sergio Zanchetta <primes2h@gmail.com>, 2023
-# Marianna Ciofani, 2025
-# Wil Odoo, 2025
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-10 08:27+0000\n"
-"PO-Revision-Date: 2022-09-22 05:45+0000\n"
-"Last-Translator: Wil Odoo, 2025\n"
-"Language-Team: Italian (https://app.transifex.com/odoo/teams/41243/it/)\n"
+"POT-Creation-Date: 2026-06-08 14:51+0000\n"
+"PO-Revision-Date: 2026-06-08 14:51+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: it\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Plural-Forms: \n"
 
 #. module: base_vat
 #. odoo-python
@@ -49,7 +42,7 @@ msgstr "1792060346001 oppure 1792060346"
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "3101012009"
-msgstr "3101012009"
+msgstr ""
 
 #. module: base_vat
 #. odoo-python
@@ -101,6 +94,22 @@ msgid "CO213123432-1 or CO213.123.432-1"
 msgstr "CO213123432-1 oppure CO213.123.432-1"
 
 #. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_company__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_change_ids
+msgid "Changeset Changes"
+msgstr "Modifiche dell'insieme di modifiche"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_company__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_ids
+msgid "Changesets"
+msgstr "Insiemi di modifiche"
+
+#. module: base_vat
 #: model:ir.model,name:base_vat.model_res_company
 msgid "Companies"
 msgstr "Aziende"
@@ -114,6 +123,30 @@ msgstr "Impostazioni di configurazione"
 #: model:ir.model,name:base_vat.model_res_partner
 msgid "Contact"
 msgstr "Contatto"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_changesets
+msgid "Count Changesets"
+msgstr "Conta insiemi di modifiche"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changeset_changes
+msgid "Count Pending Changeset Changes"
+msgstr "Conteggio modifiche dell'insieme di modifiche in attesa"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changesets
+msgid "Count Pending Changesets"
+msgstr "Conteggio insieme di modifiche in attesa"
 
 #. module: base_vat
 #. odoo-python
@@ -172,6 +205,14 @@ msgstr ""
 #, python-format
 msgid "MXGODE561231GR8 or GODE561231GR8"
 msgstr "MXGODE561231GR8 oppure GODE561231GR8"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_company__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__smart_search
+msgid "Smart Search"
+msgstr "Ricerca intelligente"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__vies_failed_message
@@ -233,6 +274,38 @@ msgstr ""
 "estero. Assegna un Paese alla posizione fiscale o configura un gruppo"
 
 #. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_company__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changeset_changes
+msgid "The number of pending changes of this record"
+msgstr "Numero di modifiche di questo record in attesa"
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_company__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changesets
+msgid "The number of pending changesets of this record"
+msgstr "Numero di insiemi di modifiche in attesa di questo record"
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_company__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_changesets
+msgid "The overall number of changesets of this record"
+msgstr "Numero totale di insiemi di modifiche di questo record"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_company__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__user_can_see_changeset
+msgid "User Can See Changeset"
+msgstr "L'utente può vedere l'insieme delle modifiche"
+
+#. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
@@ -278,4 +351,4 @@ msgstr "posizione fiscale [%s]"
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "partner [%s]"
-msgstr "partner [%s]"
+msgstr ""

--- a/addons/base_vat/i18n/ja_JP.po
+++ b/addons/base_vat/i18n/ja_JP.po
@@ -27,15 +27,15 @@ msgstr ""
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
-msgid "1111111111 (NIN) or 22222222222 (VKN)"
-msgstr ""
+msgid "17291716060 (NIN) or 1729171602 (VKN)"
+msgstr "17291716060 (NIN) または 1729171602 (VKN)"
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "1792060346001 or 1792060346"
-msgstr ""
+msgstr "1792060346001 または 1792060346"
 
 #. module: base_vat
 #. odoo-python
@@ -49,14 +49,14 @@ msgstr ""
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "310175397400003 [Fifteen digits, first and last digits should be \"3\"]"
-msgstr ""
+msgstr "310175397400003 [15桁、最初と最後の数字は \"3\"にして下さい]"
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "49-098-576 or 49098576"
-msgstr ""
+msgstr "49-098-576 または 49098576"
 
 #. module: base_vat
 #: model_terms:ir.ui.view,arch_db:base_vat.res_config_settings_view_form
@@ -71,21 +71,21 @@ msgstr ""
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "AR200-5536168-2 or 20055361682"
-msgstr ""
+msgstr "AR200-5536168-2 または 20055361682"
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "CHE-123.456.788 TVA or CHE-123.456.788 MWST or CHE-123.456.788 IVA"
-msgstr ""
+msgstr "CHE-123.456.788 TVA または CHE-123.456.788 MWST または CHE-123.456.788 IVA"
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "CO213123432-1 or CO213.123.432-1"
-msgstr ""
+msgstr "CO213123432-1 または CO213.123.432-1"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_change_ids
@@ -93,7 +93,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_change_ids
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_change_ids
 msgid "Changeset Changes"
-msgstr "Változáskészlet-változások"
+msgstr "チェンジセットの変更"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_ids
@@ -101,22 +101,22 @@ msgstr "Változáskészlet-változások"
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_ids
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_ids
 msgid "Changesets"
-msgstr "Módosításcsomagok"
+msgstr "チェンジセット"
 
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_res_company
 msgid "Companies"
-msgstr "Vállalatok"
+msgstr "会社"
 
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_res_config_settings
 msgid "Config Settings"
-msgstr "Beállítások módosítása"
+msgstr "コンフィグ設定"
 
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_res_partner
 msgid "Contact"
-msgstr "Kapcsolattartó"
+msgstr "連絡先"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_changesets
@@ -124,7 +124,7 @@ msgstr "Kapcsolattartó"
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_changesets
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__count_changesets
 msgid "Count Changesets"
-msgstr "Módosításcsomagok számlálása"
+msgstr "チェンジセット数"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changeset_changes
@@ -132,7 +132,7 @@ msgstr "Módosításcsomagok számlálása"
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changeset_changes
 msgid "Count Pending Changeset Changes"
-msgstr "Számolja a függőben lévő változtatáskészlet-változásokat"
+msgstr "保留中のチェンジセットの変更をカウント"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changesets
@@ -140,21 +140,21 @@ msgstr "Számolja a függőben lévő változtatáskészlet-változásokat"
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changesets
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changesets
 msgid "Count Pending Changesets"
-msgstr "Függő módosításkészletek számolása"
+msgstr "保留中のチェンジセットをカウント"
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "DE123456788 or 12/345/67890"
-msgstr ""
+msgstr "DE123456788 または 12/345/67890"
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "DO1-01-85004-3 or 101850043"
-msgstr ""
+msgstr "DO1-01-85004-3 または 101850043"
 
 #. module: base_vat
 #. odoo-python
@@ -162,40 +162,40 @@ msgstr ""
 #, python-format
 msgid ""
 "Example: '219999830019' (format: 12 digits, all numbers, valid check digit)"
-msgstr ""
+msgstr "例: '219999830019' (フォーマット: 112桁、全て数字、有効なチェックデジット)"
 
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_account_fiscal_position
 msgid "Fiscal Position"
-msgstr "Pénzügyi pozíció"
+msgstr "会計ポジション"
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "GB123456782 or XI123456782"
-msgstr ""
+msgstr "GB123456782 または XI123456782"
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "HU12345676 or 12345678-1-11 or 8071592153"
-msgstr ""
+msgstr "HU12345676 または 12345678-1-11 or 8071592153"
 
 #. module: base_vat
 #: model_terms:ir.ui.view,arch_db:base_vat.res_config_settings_view_form
 msgid ""
 "If this checkbox is ticked, you will not be able to save a contact if its "
 "VAT number cannot be verified by the European VIES service."
-msgstr ""
+msgstr "このチェックボックスがオンになっている場合、ヨーロッパのVIESサービスでVAT番号を確認できないと、連絡先を保存できません。"
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "MXGODE561231GR8 or GODE561231GR8"
-msgstr ""
+msgstr "MXGODE561231GR8 または GODE561231GR8"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__smart_search
@@ -203,7 +203,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__smart_search
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__smart_search
 msgid "Smart Search"
-msgstr "Intelligens keresés"
+msgstr "スマート検索"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__vies_failed_message
@@ -219,8 +219,8 @@ msgid ""
 "The %(vat_label)s number [%(wrong_vat)s] does not seem to be valid. \n"
 "Note: the expected format is %(expected_format)s"
 msgstr ""
-"A(z) %(vat_label)s szám [%(wrong_vat)s] érvénytelennek tűnik. \n"
-"Megjegyzés: a várt formátum %(expected_format)s"
+" %(vat_label)s 番号 [%(wrong_vat)s] が有効でないようです。\n"
+"メモ: 予測される形式は %(expected_format)sです。"
 
 #. module: base_vat
 #. odoo-python
@@ -230,8 +230,8 @@ msgid ""
 "The %(vat_label)s number [%(wrong_vat)s] for %(record_label)s does not seem to be valid. \n"
 "Note: the expected format is %(expected_format)s"
 msgstr ""
-"A(z) %(vat_label)s szám [%(wrong_vat)s] a(z) %(record_label)s esetében érvénytelennek tűnik. \n"
-"Megjegyzés: a várt formátum %(expected_format)s"
+"%(vat_label)s 番号 [%(wrong_vat)s]  (%(record_label)s 用)が有効ではないようです。\n"
+"メモ: 予測される形式は %(expected_format)sです。"
 
 #. module: base_vat
 #. odoo-python
@@ -247,7 +247,7 @@ msgstr ""
 msgid ""
 "The country detected for this foreign VAT number does not match any of the "
 "countries composing the country group set on this fiscal position."
-msgstr ""
+msgstr "この外国VAT番号で検出された国は、この会計ポジションで設定された国グループのいずれの国とも一致しません。"
 
 #. module: base_vat
 #. odoo-python
@@ -256,7 +256,7 @@ msgstr ""
 msgid ""
 "The country of the foreign VAT number could not be detected. Please assign a"
 " country to the fiscal position or set a country group"
-msgstr ""
+msgstr "外国VAT番号の国を検出できませんでした。会計ポジションに国を割当てるか、国グループを設定して下さい。"
 
 #. module: base_vat
 #: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changeset_changes
@@ -264,7 +264,7 @@ msgstr ""
 #: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changeset_changes
 #: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changeset_changes
 msgid "The number of pending changes of this record"
-msgstr "A bejegyzés függőben lévő módosításainak száma"
+msgstr "このレコードの保留中の変更数"
 
 #. module: base_vat
 #: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changesets
@@ -272,7 +272,7 @@ msgstr "A bejegyzés függőben lévő módosításainak száma"
 #: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changesets
 #: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changesets
 msgid "The number of pending changesets of this record"
-msgstr "A rekord folyamatban lévő módosításainak száma"
+msgstr "このレコードの保留中のチェンジセットの数"
 
 #. module: base_vat
 #: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_changesets
@@ -280,7 +280,7 @@ msgstr "A rekord folyamatban lévő módosításainak száma"
 #: model:ir.model.fields,help:base_vat.field_res_config_settings__count_changesets
 #: model:ir.model.fields,help:base_vat.field_res_partner__count_changesets
 msgid "The overall number of changesets of this record"
-msgstr "Az e rekordhoz tartozó módosítások teljes száma"
+msgstr "このレコードの全体のチェンジセット数"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__user_can_see_changeset
@@ -288,50 +288,50 @@ msgstr "Az e rekordhoz tartozó módosítások teljes száma"
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__user_can_see_changeset
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__user_can_see_changeset
 msgid "User Can See Changeset"
-msgstr "A felhasználó láthatja a változtatáskészletet"
+msgstr "ユーザーは変更セットを見ることができます"
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "VAT"
-msgstr "Adószám"
+msgstr "VAT（Value Added Tax）"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_res_company__vat_check_vies
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__vat_check_vies
 msgid "Verify VAT Numbers"
-msgstr "Adószámok ellenőrzése"
+msgstr "VAT番号を確認する"
 
 #. module: base_vat
 #: model_terms:ir.ui.view,arch_db:base_vat.res_config_settings_view_form
 msgid "Verify VAT numbers using the European VIES service"
-msgstr "Ellenőrizze az adószámokat az európai VIES szolgáltatáson keresztül"
+msgstr "ヨーロッパのVIESサービスを使用してVAT番号を確認する"
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "XXXXXXXXX [9 digits] and it should respect the Luhn algorithm checksum"
-msgstr ""
+msgstr "XXXXXXXXX [9 桁] でLuhnアルゴリズムのチェックサムにならう必要があります。"
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "either 11 digits for CPF or 14 digits for CNPJ"
-msgstr ""
+msgstr "CPF用に11桁またはCNPJ用に14桁"
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/account_fiscal_position.py:0
 #, python-format
 msgid "fiscal position [%s]"
-msgstr ""
+msgstr "財政状態 [%s]"
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "partner [%s]"
-msgstr ""
+msgstr "取引先 [%s]"

--- a/addons/base_vat/i18n/nl.po
+++ b/addons/base_vat/i18n/nl.po
@@ -1,27 +1,19 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # 	* base_vat
-# 
-# Translators:
-# Martin Trigaux, 2022
-# Jolien De Paepe, 2023
-# Manon Rondou, 2024
-# Erwin van der Ploeg <erwin@odooexperts.nl>, 2025
-# Wil Odoo, 2025
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-10 08:27+0000\n"
-"PO-Revision-Date: 2022-09-22 05:45+0000\n"
-"Last-Translator: Wil Odoo, 2025\n"
-"Language-Team: Dutch (https://app.transifex.com/odoo/teams/41243/nl/)\n"
+"POT-Creation-Date: 2026-06-08 14:51+0000\n"
+"PO-Revision-Date: 2026-06-08 14:51+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: nl\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: base_vat
 #. odoo-python
@@ -51,7 +43,7 @@ msgstr "1792060346001 of 1792060346"
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "3101012009"
-msgstr "3101012009"
+msgstr ""
 
 #. module: base_vat
 #. odoo-python
@@ -103,6 +95,22 @@ msgid "CO213123432-1 or CO213.123.432-1"
 msgstr "CO213123432-1 of CO213.123.432-1"
 
 #. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_company__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_change_ids
+msgid "Changeset Changes"
+msgstr "Wijzigingen Wijzigingen"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_company__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_ids
+msgid "Changesets"
+msgstr "Wijzigingssets"
+
+#. module: base_vat
 #: model:ir.model,name:base_vat.model_res_company
 msgid "Companies"
 msgstr "Bedrijven"
@@ -115,7 +123,31 @@ msgstr "Configuratie instellingen"
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_res_partner
 msgid "Contact"
-msgstr "Contact"
+msgstr ""
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_changesets
+msgid "Count Changesets"
+msgstr "Tel Wijzigingen"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changeset_changes
+msgid "Count Pending Changeset Changes"
+msgstr "In afwachting van wijzigingen tellen"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changesets
+msgid "Count Pending Changesets"
+msgstr "Aantal Wijzigingen"
 
 #. module: base_vat
 #. odoo-python
@@ -178,6 +210,14 @@ msgid "MXGODE561231GR8 or GODE561231GR8"
 msgstr "MXGODE561231GR8 of GODE561231GR8"
 
 #. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_company__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__smart_search
+msgid "Smart Search"
+msgstr "Slim zoeken"
+
+#. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__vies_failed_message
 #: model:ir.model.fields,field_description:base_vat.field_res_users__vies_failed_message
 msgid "Technical field display a message to the user if the VIES check fails."
@@ -237,6 +277,38 @@ msgid ""
 msgstr ""
 "Het land van het buitenlandse btw-nummer kon niet worden gedetecteerd. Wijs "
 "een land toe aan de fiscale positie of stel een landengroep in"
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_company__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changeset_changes
+msgid "The number of pending changes of this record"
+msgstr "Het aantal lopende wijzigingen van deze record"
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_company__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changesets
+msgid "The number of pending changesets of this record"
+msgstr "Het aantal hangende wijzigingssets van deze record"
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_company__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_changesets
+msgid "The overall number of changesets of this record"
+msgstr "Het totale aantal wijzigingen van deze record"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_company__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__user_can_see_changeset
+msgid "User Can See Changeset"
+msgstr "Gebruiker kan wijzigingen zien"
 
 #. module: base_vat
 #. odoo-python

--- a/addons/base_vat/i18n/pl.po
+++ b/addons/base_vat/i18n/pl.po
@@ -1,30 +1,19 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # 	* base_vat
-# 
-# Translators:
-# Maksym <ms@myodoo.pl>, 2022
-# Rafał Kozak <rafal.kozak@openglobe.pl>, 2022
-# Piotr Szlązak <szlazakpiotr@gmail.com>, 2022
-# Tomasz Leppich <t.leppich@gmail.com>, 2022
-# Martin Trigaux, 2022
-# Tadeusz Karpiński <tadeuszkarpinski@gmail.com>, 2023
-# Grzegorz Grzelak <grzegorz.grzelak@openglobe.pl>, 2023
-# Marta Wacławek, 2025
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-10 08:27+0000\n"
-"PO-Revision-Date: 2022-09-22 05:45+0000\n"
-"Last-Translator: Marta Wacławek, 2025\n"
-"Language-Team: Polish (https://app.transifex.com/odoo/teams/41243/pl/)\n"
+"POT-Creation-Date: 2026-06-08 14:51+0000\n"
+"PO-Revision-Date: 2026-06-08 14:51+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: pl\n"
-"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
+"Plural-Forms: \n"
 
 #. module: base_vat
 #. odoo-python
@@ -53,7 +42,7 @@ msgstr ""
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "3101012009"
-msgstr "3101012009"
+msgstr ""
 
 #. module: base_vat
 #. odoo-python
@@ -76,9 +65,6 @@ msgid ""
 "specific.\" aria-label=\"Values set here are company-specific.\" "
 "groups=\"base.group_multi_company\" role=\"img\"/>"
 msgstr ""
-"<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-"
-"specific.\" aria-label=\"Values set here are company-specific.\" "
-"groups=\"base.group_multi_company\" role=\"img\"/>"
 
 #. module: base_vat
 #. odoo-python
@@ -102,6 +88,22 @@ msgid "CO213123432-1 or CO213.123.432-1"
 msgstr ""
 
 #. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_company__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_change_ids
+msgid "Changeset Changes"
+msgstr "Zmiany w zestawie zmian"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_company__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_ids
+msgid "Changesets"
+msgstr "Zestawy zmian"
+
+#. module: base_vat
 #: model:ir.model,name:base_vat.model_res_company
 msgid "Companies"
 msgstr "Firmy"
@@ -115,6 +117,30 @@ msgstr "Ustawienia konfiguracji"
 #: model:ir.model,name:base_vat.model_res_partner
 msgid "Contact"
 msgstr "Kontakt"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_changesets
+msgid "Count Changesets"
+msgstr "Proszę liczyć zestawy zmian"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changeset_changes
+msgid "Count Pending Changeset Changes"
+msgstr "Proszę policzyć oczekujące zmiany w zestawie zmian"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changesets
+msgid "Count Pending Changesets"
+msgstr "Proszę policzyć oczekujące zestawy zmian"
 
 #. module: base_vat
 #. odoo-python
@@ -175,6 +201,14 @@ msgid "MXGODE561231GR8 or GODE561231GR8"
 msgstr ""
 
 #. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_company__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__smart_search
+msgid "Smart Search"
+msgstr "Inteligentne wyszukiwanie"
+
+#. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__vies_failed_message
 #: model:ir.model.fields,field_description:base_vat.field_res_users__vies_failed_message
 msgid "Technical field display a message to the user if the VIES check fails."
@@ -232,6 +266,38 @@ msgid ""
 msgstr ""
 
 #. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_company__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changeset_changes
+msgid "The number of pending changes of this record"
+msgstr "Liczba oczekujących zmian tego rekordu"
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_company__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changesets
+msgid "The number of pending changesets of this record"
+msgstr "Liczba oczekujących zestawów zmian tego rekordu"
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_company__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_changesets
+msgid "The overall number of changesets of this record"
+msgstr "Ogólna liczba zestawów zmian tego rekordu"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_company__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__user_can_see_changeset
+msgid "User Can See Changeset"
+msgstr "Użytkownik może zobaczyć zestaw zmian"
+
+#. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
@@ -275,4 +341,4 @@ msgstr "pozycja fiskalna [%s]"
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "partner [%s]"
-msgstr "partner [%s]"
+msgstr ""

--- a/addons/base_vat/i18n/pt.po
+++ b/addons/base_vat/i18n/pt.po
@@ -1,27 +1,19 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # 	* base_vat
-# 
-# Translators:
-# Manuela Silva <mmsrs@sky.com>, 2022
-# Pedro Filipe <pedro2.10@hotmail.com>, 2022
-# Reinaldo Ramos <reinaldo.ramos@arxi.pt>, 2022
-# Martin Trigaux, 2022
-# Nuno Silva <nuno.silva@arxi.pt>, 2023
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-10 08:27+0000\n"
-"PO-Revision-Date: 2022-09-22 05:45+0000\n"
-"Last-Translator: Nuno Silva <nuno.silva@arxi.pt>, 2023\n"
-"Language-Team: Portuguese (https://app.transifex.com/odoo/teams/41243/pt/)\n"
+"POT-Creation-Date: 2026-06-08 14:51+0000\n"
+"PO-Revision-Date: 2026-06-08 14:51+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: pt\n"
-"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Plural-Forms: \n"
 
 #. module: base_vat
 #. odoo-python
@@ -99,6 +91,22 @@ msgid "CO213123432-1 or CO213.123.432-1"
 msgstr ""
 
 #. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_company__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_change_ids
+msgid "Changeset Changes"
+msgstr "Alterações do conjunto de alterações"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_company__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_ids
+msgid "Changesets"
+msgstr "Conjunto de alterações"
+
+#. module: base_vat
 #: model:ir.model,name:base_vat.model_res_company
 msgid "Companies"
 msgstr "Empresas"
@@ -112,6 +120,30 @@ msgstr "Configurações"
 #: model:ir.model,name:base_vat.model_res_partner
 msgid "Contact"
 msgstr "Contacto"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_changesets
+msgid "Count Changesets"
+msgstr "Contagem de conjuntos de alterações"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changeset_changes
+msgid "Count Pending Changeset Changes"
+msgstr "Conte as alterações pendentes do conjunto de alterações"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changesets
+msgid "Count Pending Changesets"
+msgstr "Conte os conjuntos de alterações pendentes"
 
 #. module: base_vat
 #. odoo-python
@@ -169,6 +201,14 @@ msgid "MXGODE561231GR8 or GODE561231GR8"
 msgstr ""
 
 #. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_company__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__smart_search
+msgid "Smart Search"
+msgstr "Pesquisa inteligente"
+
+#. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__vies_failed_message
 #: model:ir.model.fields,field_description:base_vat.field_res_users__vies_failed_message
 msgid "Technical field display a message to the user if the VIES check fails."
@@ -182,6 +222,8 @@ msgid ""
 "The %(vat_label)s number [%(wrong_vat)s] does not seem to be valid. \n"
 "Note: the expected format is %(expected_format)s"
 msgstr ""
+"O número %(vat_label)s [%(wrong_vat)s] não parece ser válido. \n"
+"Nota: o formato esperado é %(expected_format)s"
 
 #. module: base_vat
 #. odoo-python
@@ -191,6 +233,8 @@ msgid ""
 "The %(vat_label)s number [%(wrong_vat)s] for %(record_label)s does not seem to be valid. \n"
 "Note: the expected format is %(expected_format)s"
 msgstr ""
+"O número %(vat_label)s [%(wrong_vat)s] para %(record_label)s não parece ser válido. \n"
+"Nota: o formato esperado é %(expected_format)s"
 
 #. module: base_vat
 #. odoo-python
@@ -216,6 +260,38 @@ msgid ""
 "The country of the foreign VAT number could not be detected. Please assign a"
 " country to the fiscal position or set a country group"
 msgstr ""
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_company__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changeset_changes
+msgid "The number of pending changes of this record"
+msgstr "O número de alterações pendentes deste registo"
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_company__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changesets
+msgid "The number of pending changesets of this record"
+msgstr "O número de conjuntos de alterações pendentes deste registo"
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_company__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_changesets
+msgid "The overall number of changesets of this record"
+msgstr "O número total de conjuntos de alterações deste registo"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_company__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__user_can_see_changeset
+msgid "User Can See Changeset"
+msgstr "O utilizador pode ver o conjunto de alterações"
 
 #. module: base_vat
 #. odoo-python

--- a/addons/base_vat/i18n/ru.po
+++ b/addons/base_vat/i18n/ru.po
@@ -1,27 +1,19 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # 	* base_vat
-# 
-# Translators:
-# Сергей Шебанин <sergey@shebanin.ru>, 2022
-# ILMIR <karamov@it-projects.info>, 2022
-# Martin Trigaux, 2023
-# Wil Odoo, 2024
-# Ilya Rozhkov, 2025
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-10 08:27+0000\n"
-"PO-Revision-Date: 2022-09-22 05:45+0000\n"
-"Last-Translator: Ilya Rozhkov, 2025\n"
-"Language-Team: Russian (https://app.transifex.com/odoo/teams/41243/ru/)\n"
+"POT-Creation-Date: 2026-06-08 14:51+0000\n"
+"PO-Revision-Date: 2026-06-08 14:51+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: \n"
 
 #. module: base_vat
 #. odoo-python
@@ -51,7 +43,7 @@ msgstr "1792060346001 или 1792060346"
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "3101012009"
-msgstr "3101012009"
+msgstr ""
 
 #. module: base_vat
 #. odoo-python
@@ -101,6 +93,22 @@ msgid "CO213123432-1 or CO213.123.432-1"
 msgstr "CO213123432-1 или CO213.123.432-1"
 
 #. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_company__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_change_ids
+msgid "Changeset Changes"
+msgstr "Набор изменений Изменения"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_company__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_ids
+msgid "Changesets"
+msgstr "Наборы изменений"
+
+#. module: base_vat
 #: model:ir.model,name:base_vat.model_res_company
 msgid "Companies"
 msgstr "Компании"
@@ -114,6 +122,30 @@ msgstr "Конфигурационные настройки"
 #: model:ir.model,name:base_vat.model_res_partner
 msgid "Contact"
 msgstr "Контакт"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_changesets
+msgid "Count Changesets"
+msgstr "Наборы изменений"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changeset_changes
+msgid "Count Pending Changeset Changes"
+msgstr "Подсчет ожидающих изменений набора изменений"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changesets
+msgid "Count Pending Changesets"
+msgstr "Подсчет ожидающих изменений"
 
 #. module: base_vat
 #. odoo-python
@@ -173,6 +205,14 @@ msgid "MXGODE561231GR8 or GODE561231GR8"
 msgstr "MXGODE561231GR8 или GODE561231GR8"
 
 #. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_company__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__smart_search
+msgid "Smart Search"
+msgstr "Умный поиск"
+
+#. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__vies_failed_message
 #: model:ir.model.fields,field_description:base_vat.field_res_users__vies_failed_message
 msgid "Technical field display a message to the user if the VIES check fails."
@@ -228,6 +268,38 @@ msgid ""
 msgstr ""
 "Не удалось определить страну иностранного номера НДС. Укажите страну или "
 "группу стран в налоговой позиции."
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_company__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changeset_changes
+msgid "The number of pending changes of this record"
+msgstr "Количество ожидающих изменений этой записи"
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_company__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changesets
+msgid "The number of pending changesets of this record"
+msgstr "Количество ожидающих изменений этой записи"
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_company__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_changesets
+msgid "The overall number of changesets of this record"
+msgstr "Общее количество наборов изменений этой записи"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_company__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__user_can_see_changeset
+msgid "User Can See Changeset"
+msgstr "Пользователь может видеть набор изменений"
 
 #. module: base_vat
 #. odoo-python

--- a/addons/base_vat/i18n/tr.po
+++ b/addons/base_vat/i18n/tr.po
@@ -1,31 +1,19 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # 	* base_vat
-# 
-# Translators:
-# Ediz Duman <neps1192@gmail.com>, 2022
-# abc Def <hdogan1974@gmail.com>, 2022
-# Levent Karakaş <levent@mektup.at>, 2022
-# Murat Kaplan <muratk@projetgrup.com>, 2022
-# Umur Akın <umura@projetgrup.com>, 2022
-# Tugay Hatıl <tugayh@projetgrup.com>, 2023
-# Ayhan Kızıltan, 2024
-# Ertuğrul Güreş <ertugrulg@projetgrup.com>, 2024
-# Deniz Guvener_Odoo <degu@odoo.com>, 2025
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-10 08:27+0000\n"
-"PO-Revision-Date: 2022-09-22 05:45+0000\n"
-"Last-Translator: Deniz Guvener_Odoo <degu@odoo.com>, 2025\n"
-"Language-Team: Turkish (https://app.transifex.com/odoo/teams/41243/tr/)\n"
+"POT-Creation-Date: 2026-06-08 14:51+0000\n"
+"PO-Revision-Date: 2026-06-08 14:51+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: tr\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: \n"
 
 #. module: base_vat
 #. odoo-python
@@ -79,9 +67,6 @@ msgid ""
 "specific.\" aria-label=\"Values set here are company-specific.\" "
 "groups=\"base.group_multi_company\" role=\"img\"/>"
 msgstr ""
-"<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-"
-"specific.\" aria-label=\"Values set here are company-specific.\" "
-"groups=\"base.group_multi_company\" role=\"img\"/>"
 
 #. module: base_vat
 #. odoo-python
@@ -105,9 +90,25 @@ msgid "CO213123432-1 or CO213.123.432-1"
 msgstr ""
 
 #. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_company__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_change_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_change_ids
+msgid "Changeset Changes"
+msgstr "Changeset Değişiklikleri"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_company__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_ids
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_ids
+msgid "Changesets"
+msgstr "Değişiklikler"
+
+#. module: base_vat
 #: model:ir.model,name:base_vat.model_res_company
 msgid "Companies"
-msgstr "Şirketler"
+msgstr "Firmalar"
 
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_res_config_settings
@@ -118,6 +119,30 @@ msgstr "Yapılandırma Ayarları"
 #: model:ir.model,name:base_vat.model_res_partner
 msgid "Contact"
 msgstr "Kontak"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_changesets
+msgid "Count Changesets"
+msgstr "Sayım Değişiklik Setleri"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changeset_changes
+msgid "Count Pending Changeset Changes"
+msgstr "Bekleyen Değişiklik Seti Değişikliklerini Say"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_company__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changesets
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changesets
+msgid "Count Pending Changesets"
+msgstr "Bekleyen Değişiklik Setlerini Say"
 
 #. module: base_vat
 #. odoo-python
@@ -177,6 +202,14 @@ msgid "MXGODE561231GR8 or GODE561231GR8"
 msgstr ""
 
 #. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_company__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__smart_search
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__smart_search
+msgid "Smart Search"
+msgstr "Akıllı Arama"
+
+#. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__vies_failed_message
 #: model:ir.model.fields,field_description:base_vat.field_res_users__vies_failed_message
 msgid "Technical field display a message to the user if the VIES check fails."
@@ -234,6 +267,38 @@ msgid ""
 msgstr ""
 "Yabancı KDV numarasının ülkesi tespit edilemedi. Lütfen mali koşula bir ülke"
 " atayın veya bir ülke grubu ayarlayın"
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_company__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changeset_changes
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changeset_changes
+msgid "The number of pending changes of this record"
+msgstr "Bu kaydın bekleyen değişiklik sayısı"
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_company__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changesets
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changesets
+msgid "The number of pending changesets of this record"
+msgstr "Bu kaydın bekleyen değişiklik setlerinin sayısı"
+
+#. module: base_vat
+#: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_company__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_config_settings__count_changesets
+#: model:ir.model.fields,help:base_vat.field_res_partner__count_changesets
+msgid "The overall number of changesets of this record"
+msgstr "Bu kaydın toplam değişiklik seti sayısı"
+
+#. module: base_vat
+#: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_company__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_config_settings__user_can_see_changeset
+#: model:ir.model.fields,field_description:base_vat.field_res_partner__user_can_see_changeset
+msgid "User Can See Changeset"
+msgstr "Kullanıcı Değişiklikleri Görebilir"
 
 #. module: base_vat
 #. odoo-python

--- a/addons/base_vat/i18n/zh_HK.po
+++ b/addons/base_vat/i18n/zh_HK.po
@@ -27,7 +27,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
-msgid "1111111111 (NIN) or 22222222222 (VKN)"
+msgid "17291716060 (NIN) or 1729171602 (VKN)"
 msgstr ""
 
 #. module: base_vat
@@ -93,7 +93,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_change_ids
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_change_ids
 msgid "Changeset Changes"
-msgstr "Változáskészlet-változások"
+msgstr "变更集变更"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__changeset_ids
@@ -101,22 +101,22 @@ msgstr "Változáskészlet-változások"
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__changeset_ids
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__changeset_ids
 msgid "Changesets"
-msgstr "Módosításcsomagok"
+msgstr "变更集"
 
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_res_company
 msgid "Companies"
-msgstr "Vállalatok"
+msgstr "公司"
 
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_res_config_settings
 msgid "Config Settings"
-msgstr "Beállítások módosítása"
+msgstr "配置设置"
 
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_res_partner
 msgid "Contact"
-msgstr "Kapcsolattartó"
+msgstr "聯絡人"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_changesets
@@ -124,7 +124,7 @@ msgstr "Kapcsolattartó"
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_changesets
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__count_changesets
 msgid "Count Changesets"
-msgstr "Módosításcsomagok számlálása"
+msgstr "计数变更集"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changeset_changes
@@ -132,7 +132,7 @@ msgstr "Módosításcsomagok számlálása"
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changeset_changes
 msgid "Count Pending Changeset Changes"
-msgstr "Számolja a függőben lévő változtatáskészlet-változásokat"
+msgstr "统计待处理的变更集变更"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__count_pending_changesets
@@ -140,7 +140,7 @@ msgstr "Számolja a függőben lévő változtatáskészlet-változásokat"
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__count_pending_changesets
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__count_pending_changesets
 msgid "Count Pending Changesets"
-msgstr "Függő módosításkészletek számolása"
+msgstr "统计待处理的变更集"
 
 #. module: base_vat
 #. odoo-python
@@ -167,7 +167,7 @@ msgstr ""
 #. module: base_vat
 #: model:ir.model,name:base_vat.model_account_fiscal_position
 msgid "Fiscal Position"
-msgstr "Pénzügyi pozíció"
+msgstr ""
 
 #. module: base_vat
 #. odoo-python
@@ -203,7 +203,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__smart_search
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__smart_search
 msgid "Smart Search"
-msgstr "Intelligens keresés"
+msgstr "智能搜索"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__vies_failed_message
@@ -219,8 +219,8 @@ msgid ""
 "The %(vat_label)s number [%(wrong_vat)s] does not seem to be valid. \n"
 "Note: the expected format is %(expected_format)s"
 msgstr ""
-"A(z) %(vat_label)s szám [%(wrong_vat)s] érvénytelennek tűnik. \n"
-"Megjegyzés: a várt formátum %(expected_format)s"
+"%(vat_label)s数字[%(wrong_vat)s]似乎无效。\n"
+"注：预期格式为%(expected_format)s"
 
 #. module: base_vat
 #. odoo-python
@@ -230,8 +230,8 @@ msgid ""
 "The %(vat_label)s number [%(wrong_vat)s] for %(record_label)s does not seem to be valid. \n"
 "Note: the expected format is %(expected_format)s"
 msgstr ""
-"A(z) %(vat_label)s szám [%(wrong_vat)s] a(z) %(record_label)s esetében érvénytelennek tűnik. \n"
-"Megjegyzés: a várt formátum %(expected_format)s"
+"%(vat_label)s数字[%(wrong_vat)s]用于%(record_label)s，似乎无效。\n"
+"注：预期格式为%(expected_format)s"
 
 #. module: base_vat
 #. odoo-python
@@ -264,7 +264,7 @@ msgstr ""
 #: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changeset_changes
 #: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changeset_changes
 msgid "The number of pending changes of this record"
-msgstr "A bejegyzés függőben lévő módosításainak száma"
+msgstr "此记录的待更改次数"
 
 #. module: base_vat
 #: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_pending_changesets
@@ -272,7 +272,7 @@ msgstr "A bejegyzés függőben lévő módosításainak száma"
 #: model:ir.model.fields,help:base_vat.field_res_config_settings__count_pending_changesets
 #: model:ir.model.fields,help:base_vat.field_res_partner__count_pending_changesets
 msgid "The number of pending changesets of this record"
-msgstr "A rekord folyamatban lévő módosításainak száma"
+msgstr "此记录的待处理更改集数量"
 
 #. module: base_vat
 #: model:ir.model.fields,help:base_vat.field_account_fiscal_position__count_changesets
@@ -280,7 +280,7 @@ msgstr "A rekord folyamatban lévő módosításainak száma"
 #: model:ir.model.fields,help:base_vat.field_res_config_settings__count_changesets
 #: model:ir.model.fields,help:base_vat.field_res_partner__count_changesets
 msgid "The overall number of changesets of this record"
-msgstr "Az e rekordhoz tartozó módosítások teljes száma"
+msgstr "该记录的更改集总数"
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_account_fiscal_position__user_can_see_changeset
@@ -288,25 +288,25 @@ msgstr "Az e rekordhoz tartozó módosítások teljes száma"
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__user_can_see_changeset
 #: model:ir.model.fields,field_description:base_vat.field_res_partner__user_can_see_changeset
 msgid "User Can See Changeset"
-msgstr "A felhasználó láthatja a változtatáskészletet"
+msgstr "用户可查看变更集"
 
 #. module: base_vat
 #. odoo-python
 #: code:addons/base_vat/models/res_partner.py:0
 #, python-format
 msgid "VAT"
-msgstr "Adószám"
+msgstr ""
 
 #. module: base_vat
 #: model:ir.model.fields,field_description:base_vat.field_res_company__vat_check_vies
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__vat_check_vies
 msgid "Verify VAT Numbers"
-msgstr "Adószámok ellenőrzése"
+msgstr ""
 
 #. module: base_vat
 #: model_terms:ir.ui.view,arch_db:base_vat.res_config_settings_view_form
 msgid "Verify VAT numbers using the European VIES service"
-msgstr "Ellenőrizze az adószámokat az európai VIES szolgáltatáson keresztül"
+msgstr ""
 
 #. module: base_vat
 #. odoo-python


### PR DESCRIPTION
## Summary

The storefront (website-next PR #226) now surfaces base_vat's VAT `ValidationError` ("The VAT number [...] does not seem to be valid. Note: the expected format is ...") directly to customers, localized via the request lang context. Several installed languages had no translation for it and fell back to English.

## Changes (all under `addons/base_vat/i18n/`)

- **Regenerated** the .po files for the languages installed in our DB (smart-button export): refreshes `tr, de, fr, ru, es, it, nl, pl, bg, hu, pt` + `base_vat.pot`, and adds the full-locale files `el_GR, ar_001, en_US, ja_JP, zh_HK`.
- **Filled the missing translations** (both message variants, with and without the record label) in:
  - `bg.po`, `hu.po`, `pt.po` (were empty),
  - `el_GR.po` (the file Odoo actually reads for Greek; the shipped `el.po` is stale and lacks the current msgids),
  - `zh_HK.po` (the installed Chinese; `zh_CN.po` is never consulted for `zh_HK` since there is no `zh.po` base).

With this, every storefront language gets a localized VAT error message.

## Notes

- The expected-format example values (e.g. "1111111111 (NIN) or 22222222222 (VKN)") remain untranslated at runtime: `_ref_vat` is a module-level dict, so `_()` evaluates at import with no language. Upstream quirk, independent of these files.
- Code translations are read from the .po files and cached per worker, so a server restart applies them (no module upgrade needed).
- The regenerated export also drops Transifex translator-credit headers and pulls in msgids contributed to base_vat-owned models by other installed modules (e.g. changeset fields); functional content is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)